### PR TITLE
Update RucksackReorganization.java

### DIFF
--- a/2022/03/RucksackReorganization.java
+++ b/2022/03/RucksackReorganization.java
@@ -3,9 +3,6 @@ import java.io.IOException;
 import java.util.*;
 
 public class RucksackReorganization {
-
-
-
     public static void main(String args[]) {
 
         Map<Character, Integer> prio = new HashMap<>();
@@ -36,10 +33,9 @@ public class RucksackReorganization {
                     char cur = compartmentOne.charAt(i);
                     if(compartmentTwo.indexOf(cur) >= 0) {
                         sum += prio.get(cur);
-                        continue;
+                        break;
                     }
                 }
-
             }
             sc.close();
 
@@ -48,6 +44,5 @@ public class RucksackReorganization {
         }
 
         System.out.println("prios: " + sum);
-
     }
 }


### PR DESCRIPTION
Fixed a bug where characters in the compartmentOne String were checked multiple times causing duplicate increments of the sum.

Example:
```
a b a b b | b b b b a
^   ^
Both a's get evaluated, both match with the final a in the second half, both (erroneously) increment the sum.
```
debugged with the help of @egzoshift